### PR TITLE
No log body in browser console

### DIFF
--- a/browser/Logger.js
+++ b/browser/Logger.js
@@ -205,7 +205,7 @@ class Logger extends LoggerBase {
     };
 
     if (console[map[level]]) {
-      console[map[level]](log.message, log);
+      console[map[level]](`[${level.toUpperCase()}]`, log.message);
     }
   }
 


### PR DESCRIPTION
Еще одна причина транслировать всё на сервер для отображения в консоли в нормальном формате.
А в браузере пусть только сообщение и level ошибки.
