### PR TITLE
Silent redirects feature

### DIFF
--- a/browser/DocumentRenderer.js
+++ b/browser/DocumentRenderer.js
@@ -188,15 +188,22 @@ class DocumentRenderer extends DocumentRendererBase {
    * Update state by new url location.
    * @param {Object} urlState
    * @param {Object} routingContext
+   * @param {Object} options
+   * @param {boolean} options.silent
    * @returns {Promise} Promise for nothing.
    */
-  updateState (urlState, routingContext) {
+  updateState (urlState, routingContext, options = {}) {
     return this._getPromiseForReadyState()
       .then(() => {
         this._currentRoutingContext = routingContext;
         this._currentUrlState = urlState;
 
         this._state.setRoutingContext(routingContext);
+
+        if (options.silent) {
+          return Promise.resolve();
+        }
+
         return this._state.runSignal(urlState.signal, urlState.args);
       })
       .catch(reason => this._eventBus.emit('error', reason));

--- a/browser/providers/ModuleApiProvider.js
+++ b/browser/providers/ModuleApiProvider.js
@@ -29,11 +29,13 @@ class ModuleApiProvider extends ModuleApiProviderBase {
   /**
    * Redirects current page to specified URI.
    * @param {string} uriString URI to redirect.
+   * @param {Object} options
+   * @param {boolean} options.silent routing without run signal related to URI
    * @returns {Promise} Promise for nothing.
    */
-  redirect (uriString) {
+  redirect (uriString, options) {
     var requestRouter = this.locator.resolve('requestRouter');
-    return requestRouter.go(uriString);
+    return requestRouter.go(uriString, options);
   }
 
   /**


### PR DESCRIPTION
New feature: Silent Redirects (Browser)

Sometimes you don't want run signal on every url change, you can define signal (smaller than page signal) that transfer state to new URI state. It's useful for query pages (filters, pagination, etc).

It's experimental feature, use it carefully.
