### PR TITLE
Browserify stream error logger bugfix

### DIFF
--- a/lib/builders/BrowserBundleBuilder.js
+++ b/lib/builders/BrowserBundleBuilder.js
@@ -195,7 +195,10 @@ class BrowserBundleBuilder {
             .once('bundle', bundleStream => {
               bundleStream
                 .once('end', () => resolve())
-                .on('error', e => reject(e));
+                .on('error', e => {
+                  delete e.stream;
+                  reject(e);
+                });
             })
             .bundle();
         });


### PR DESCRIPTION
Fixed, show console error log, when throw error in browserify bundler.
