### PR TITLE
Rework URL Mapping, add mapFn to routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ module.exports = [
   {
     expression: '/news/:id', // id is dynamic arg
     signal: 'newsRoute',
+    map: mapFn,
     args: {
       page: 'newsCard' // static args
     }

--- a/browser/RequestRouter.js
+++ b/browser/RequestRouter.js
@@ -152,8 +152,7 @@ class RequestRouter {
           return Promise.resolve();
         }
 
-        var args = this._urlArgsProvider.getArgsByUri(location);
-        var signal = this._urlArgsProvider.getSignalByUri(location);
+        var { args, signal } = this._urlArgsProvider.getArgsAndSignalByUri(location);
 
         if (!args || !signal) {
           this._window.location.assign(locationString);
@@ -177,8 +176,7 @@ class RequestRouter {
     return Promise.resolve()
       .then(() => {
         this._location = newLocation;
-        var args = this._urlArgsProvider.getArgsByUri(newLocation);
-        var signal = this._urlArgsProvider.getSignalByUri(newLocation);
+        var { args, signal } = this._urlArgsProvider.getArgsAndSignalByUri(newLocation);
 
         var routingContext = this._contextFactory.create({
           referrer: this._referrer || this._window.document.referrer,

--- a/lib/RequestRouter.js
+++ b/lib/RequestRouter.js
@@ -89,8 +89,7 @@ class RequestRouter {
       cookieString = String(request.headers.cookie || '');
     }
 
-    var args = this._urlArgsProvider.getArgsByUri(location);
-    var signal = this._urlArgsProvider.getSignalByUri(location);
+    var { args, signal } = this._urlArgsProvider.getArgsAndSignalByUri(location);
 
     if (!args || !signal) {
       next();

--- a/lib/helpers/routeHelper.js
+++ b/lib/helpers/routeHelper.js
@@ -87,7 +87,6 @@ module.exports = {
       map: uri => {
         var args = Object.create(null);
 
-
         if (pathMapper) {
           pathMapper(uri.path, args);
         }

--- a/lib/providers/URLArgsProvider.js
+++ b/lib/providers/URLArgsProvider.js
@@ -15,47 +15,25 @@ class URLArgsProvider {
   _uriMappers = null;
 
   /**
-   * Gets args by specified location URI.
+   * Gets args and signals by specified location URI.
    * @param {URI} location URI location.
    * @returns {Object} Args object.
    */
-  getArgsByUri (location) {
+  getArgsAndSignalByUri (location) {
     if (this._uriMappers.length === 0) {
-      return null;
+      return {
+        signal: null,
+        args: null
+      };
     }
 
     location = location.clone();
     location.path = routeHelper.removeEndSlash(location.path);
 
     var args = getArgs(this._uriMappers, location);
-
-    if (!args) {
-      return null;
-    }
-
-    return args;
-  }
-
-  /**
-   * Gets signal by specified location URI.
-   * @param {URI} location URI location
-   * @returns {String}
-   */
-  getSignalByUri (location) {
-    if (this._uriMappers.length === 0) {
-      return null;
-    }
-
-    location = location.clone();
-    location.path = routeHelper.removeEndSlash(location.path);
-
     var signal = getSignal(this._uriMappers, location);
 
-    if (!signal) {
-      return null;
-    }
-
-    return signal;
+    return runPostMapping({ args, signal }, this._uriMappers, location);
   }
 }
 
@@ -77,7 +55,8 @@ function getUriMappers (serviceLocator) {
       uriMappers.push({
         expression: mapper.expression,
         signal: route.signal,
-        map: uri => {
+        map: route.map || noop,
+        argsMap: uri => {
           var args = mapper.map(uri);
           Object.assign(args, route.args);
           return args;
@@ -108,7 +87,7 @@ function getSignal (uriMappers, location) {
 }
 
 /**
- * Gets args.
+ * Gets args
  * @param {Array} uriMappers
  * @param {URI} location
  * @returns {Object|null}
@@ -118,13 +97,40 @@ function getArgs (uriMappers, location) {
 
   uriMappers.some(mapper => {
     if (mapper.expression.test(location.path)) {
-      args = mapper.map(location) || Object.create(null);
+      args = mapper.argsMap(location) || Object.create(null);
       return true;
     }
     return false;
   });
 
   return args;
+}
+
+/**
+ * Run handler after signal and args was get
+ * @param {Object} data
+ * @param {Array} uriMappers
+ * @param {URI} location
+ */
+function runPostMapping (data, uriMappers, location) {
+  uriMappers.some(mapper => {
+    if (mapper.expression.test(location.path)) {
+      data = mapper.map(data);
+      return true;
+    }
+    return false;
+  });
+
+  return data;
+}
+
+/**
+ * Noop function
+ * @param {*} data
+ * @returns {*}
+ */
+function noop (data) {
+  return data;
 }
 
 module.exports = URLArgsProvider;

--- a/lib/providers/URLArgsProvider.js
+++ b/lib/providers/URLArgsProvider.js
@@ -111,6 +111,7 @@ function getArgs (uriMappers, location) {
  * @param {Object} data
  * @param {Array} uriMappers
  * @param {URI} location
+ * @return {Object}
  */
 function runPostMapping (data, uriMappers, location) {
   uriMappers.some(mapper => {

--- a/test/cases/lib/providers/URLArgsProvider.json
+++ b/test/cases/lib/providers/URLArgsProvider.json
@@ -1,5 +1,5 @@
 {
-  "getArgsByUri": [
+  "getArgsAndSignalByUri": [
     {
       "name": "should return null if URI is not routed",
       "routes": [
@@ -8,7 +8,10 @@
         }
       ],
       "uri": "/none",
-      "expectedArgs": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should return null if URI is not a string",
@@ -18,7 +21,10 @@
         }
       ],
       "uri": null,
-      "expectedArgs": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should return null if URI is empty string",
@@ -28,7 +34,10 @@
         }
       ],
       "uri": "",
-      "expectedArgs": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should return null if there are not routes",
@@ -36,7 +45,10 @@
 
       ],
       "uri": "/state/value/?a=1&b=2",
-      "expectedArgs": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should return null if route is empty",
@@ -49,7 +61,10 @@
         }
       ],
       "uri": "/state/value/?a=1&b=2",
-      "expectedArgs": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should return args object if URI is routed",
@@ -59,8 +74,11 @@
         }
       ],
       "uri": "/state/test",
-      "expectedArgs": {
-        "arg": "test"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg": "test"
+        }
       }
     },
     {
@@ -71,8 +89,11 @@
         }
       ],
       "uri": "/state?arg=test",
-      "expectedArgs": {
-        "arg": "test"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg": "test"
+        }
       }
     },
     {
@@ -83,9 +104,12 @@
         }
       ],
       "uri": "/state?arg1=test&arg2=test",
-      "expectedArgs": {
-        "arg1": "test",
-        "arg2": "test"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "test",
+          "arg2": "test"
+        }
       }
     },
     {
@@ -96,9 +120,12 @@
         }
       ],
       "uri": "/state/val1/val2?c=val3&d=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2"
+        }
       }
     },
     {
@@ -113,10 +140,13 @@
         }
       ],
       "uri": "/state?arg1=test&arg2=test",
-      "expectedArgs": {
-        "arg1": "overwritten",
-        "arg2": "test",
-        "arg3": "extended"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "overwritten",
+          "arg2": "test",
+          "arg3": "extended"
+        }
       }
     },
     {
@@ -130,9 +160,12 @@
         }
       ],
       "uri": "/state/val1/val2?a=val3&b=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2"
+        }
       }
     },
     {
@@ -146,11 +179,14 @@
         }
       ],
       "uri": "/state/val1/val2?a=val3&b=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2",
-        "arg3": "val3",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2",
+          "arg3": "val3",
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -161,11 +197,14 @@
         }
       ],
       "uri": "/state/val1/val2?a=val3&b=val4&a=val5&a=val6",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2",
-        "arg3": ["val3","val5","val6"],
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2",
+          "arg3": ["val3","val5","val6"],
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -176,10 +215,13 @@
         }
       ],
       "uri": "/state/val1/val2?a=val3&b=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2",
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -190,11 +232,14 @@
         }
       ],
       "uri": "/state/val1/val2?b=val4&a=val3",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2",
-        "arg3": "val3",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2",
+          "arg3": "val3",
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -205,9 +250,12 @@
         }
       ],
       "uri": "/state/val1/val2?",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2"
+        }
       }
     },
     {
@@ -218,11 +266,14 @@
         }
       ],
       "uri": "/state/val1/val2?a=&b=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg2": "val2",
-        "arg3": "",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg2": "val2",
+          "arg3": "",
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -233,9 +284,12 @@
         }
       ],
       "uri": "/state?a=val3&b=val4",
-      "expectedArgs": {
-        "arg3": "val3",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg3": "val3",
+          "arg4": "val4"
+        }
       }
     },
     {
@@ -246,14 +300,15 @@
         }
       ],
       "uri": "/state/val1/val2?a=valX&b=val4",
-      "expectedArgs": {
-        "arg1": "val1",
-        "arg3": "valX",
-        "arg4": "val4"
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+          "arg1": "val1",
+          "arg3": "valX",
+          "arg4": "val4"
+        }
       }
-    }
-  ],
-  "getSignalByUri": [
+    },
     {
       "name": "should return signal name if it's defined in route and URI is routed",
       "routes": [
@@ -263,7 +318,10 @@
         }
       ],
       "uri": "/",
-      "expectedSignal": "test"
+      "expectedArgsAndSignal": {
+        "signal": "test",
+        "args": {}
+      }
     },
     {
       "name": "should not return signal name if it's not defined in route and URI is routed",
@@ -273,7 +331,12 @@
         }
       ],
       "uri": "/",
-      "expectedSignal": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": {
+
+        }
+      }
     },
     {
       "name": "should not return signal name if it's defined in route but URI is not routed",
@@ -284,7 +347,10 @@
         }
       ],
       "uri": "/",
-      "expectedSignal": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     },
     {
       "name": "should not return signal name if it's not defined in route and URI is not routed",
@@ -294,7 +360,10 @@
         }
       ],
       "uri": "/",
-      "expectedSignal": null
+      "expectedArgsAndSignal": {
+        "signal": null,
+        "args": null
+      }
     }
   ]
 }

--- a/test/lib/providers/URLArgsProvider.js
+++ b/test/lib/providers/URLArgsProvider.js
@@ -8,29 +8,39 @@ var URI = require('catberry-uri').URI;
 var testCases = require('../../cases/lib/providers/URLArgsProvider.json');
 
 lab.experiment('lib/providers/URLArgsProvider', function () {
-  lab.experiment('#getArgsByUri', function () {
-    testCases.getArgsByUri.forEach(function (testCase) {
+  lab.experiment('#getArgsAndSignalByUri', function () {
+    testCases.getArgsAndSignalByUri.forEach(function (testCase) {
       lab.test(testCase.name, function (done) {
         var locator = createLocator(testCase.routes);
         var provider = locator.resolveInstance(URLArgsProvider);
         var uri = new URI(testCase.uri);
-        var args = provider.getArgsByUri(uri);
-        assert.deepEqual(args, testCase.expectedArgs);
+        var argsAndSignal = provider.getArgsAndSignalByUri(uri);
+        assert.deepEqual(argsAndSignal, testCase.expectedArgsAndSignal);
         done();
       });
     });
-  });
 
-  lab.experiment('#getSignalByUri', function () {
-    testCases.getSignalByUri.forEach(function (testCase) {
-      lab.test(testCase.name, function (done) {
-        var locator = createLocator(testCase.routes);
-        var provider = locator.resolveInstance(URLArgsProvider);
-        var uri = new URI(testCase.uri);
-        var signal = provider.getSignalByUri(uri);
-        assert.deepEqual(signal, testCase.expectedSignal);
-        done();
+    lab.test('Should map args if method map passed', function (done) {
+      var locator = createLocator([
+        {
+          expression: '/',
+          signal: 'Hello',
+          map: function ({ signal, args }) {
+            signal = 'test';
+            return { signal, args };
+          }
+        }
+      ]);
+
+      var provider = locator.resolveInstance(URLArgsProvider);
+      var uri = new URI('/');
+
+      var argsAndSignal = provider.getArgsAndSignalByUri(uri);
+      assert.deepEqual(argsAndSignal, {
+        args: {},
+        signal: 'test'
       });
+      done();
     });
   });
 });


### PR DESCRIPTION
Sometimes you have logic around signal name and passed args in route definition.
We return Catberry map function, but specified for args/signals.

Example: 
```
{
  expression: '/news/:filter,
  signal: 'ActiveNewsPage',
  map: function ({ signal, args }) {
     if (args.filter === 'Archive') {
        signal = 'ArchiveNewsPage';
     }

     return { signal, args };
  }
}
```