### PR TITLE
Add custom config fields for signals/watchers/actions finders

### DIFF
--- a/lib/finders/SignalFinder.js
+++ b/lib/finders/SignalFinder.js
@@ -27,17 +27,19 @@ class SignalFinder extends EventEmitter {
    * Load and watch for signals and actions in folders
    * Emit events when signal or action is reloaded
    * @param {EventEmitter} $eventBus
+   * @param {String?} signalsFolder
+   * @param {String?} actionsFolder
    */
-  constructor ($eventBus) {
+  constructor ($eventBus, signalsFolder, actionsFolder) {
     super();
 
     this._eventBus = $eventBus;
 
-    this._signalsFolder = SIGNALS_DEFAULT_FOLDER;
+    this._signalsFolder = signalsFolder || SIGNALS_DEFAULT_FOLDER;
     this._signalsGlobExpression = path.join(this._signalsFolder, SIGNALS_DEFAULT_GLOB);
     this._signalsGlobExpression = requireHelper.getValidPath(this._signalsGlobExpression);
 
-    this._actionsFolder = ACTIONS_DEFAULT_FOLDER;
+    this._actionsFolder = actionsFolder || ACTIONS_DEFAULT_FOLDER;
     this._actionsGlobExpression = path.join(this._actionsFolder, ACTIONS_DEFAULT_GLOB);
     this._actionsGlobExpression = requireHelper.getValidPath(this._actionsGlobExpression);
   }

--- a/lib/finders/WatcherFinder.js
+++ b/lib/finders/WatcherFinder.js
@@ -21,12 +21,18 @@ const WATCHERS_DEFAULT_FOLDER = 'watchers';
 const WATCHERS_DEFAULT_GLOB = '**/*.js';
 
 class WatcherFinder extends EventEmitter {
-  constructor ($eventBus) {
+  /**
+   * Load and watch for watcher in folder
+   * Emit events when watcher is updated
+   * @param {EventEmitter} $eventBus
+   * @param {String?} watchersFolder
+   */
+  constructor ($eventBus, watchersFolder) {
     super();
 
     this._eventBus = $eventBus;
 
-    this._watchersFolder = WATCHERS_DEFAULT_FOLDER;
+    this._watchersFolder = watchersFolder || WATCHERS_DEFAULT_FOLDER;
     this._watchersGlobExpression = path.join(this._watchersFolder, WATCHERS_DEFAULT_GLOB);
     this._watchersGlobExpression = requireHelper.getValidPath(this._watchersGlobExpression);
   }


### PR DESCRIPTION
This PR allow customize paths to signals/actions/watchers folders, component glob also supported and have same API with Catberry.