### PR TITLE
Remove excessive validation

### DIFF
--- a/lib/builders/BootstrapperBuilder.js
+++ b/lib/builders/BootstrapperBuilder.js
@@ -127,16 +127,8 @@ class BootstrapperBuilder {
         var logicFile = components[componentName].properties.logic || moduleHelper.DEFAULT_LOGIC_FILENAME;
         var logicPath = path.resolve(componentPath, logicFile);
         var relativeLogicPath = path.relative(process.cwd(), logicPath);
-        var constructor;
 
-        try {
-          constructor = require(logicPath);
-        } catch (e) {
-          this._eventBus.emit('error', e);
-        }
-
-        if (typeof (constructor) !== 'function' ||
-          typeof (componentDetails.properties.template) !== 'string') {
+        if (typeof (componentDetails.properties.template) !== 'string') {
           return;
         }
 


### PR DESCRIPTION
Now we check components for functions export on build step, it's cool feature but if we have big project with 200+ components, it's take much time, and also you must register require hooks for babel/cssmodules and any other code transforms. I think we must exclude this feature for better build performance. 